### PR TITLE
Kallisto Meta Flip Conditional Fix

### DIFF
--- a/src/kallisto/Kallisto.cpp
+++ b/src/kallisto/Kallisto.cpp
@@ -596,7 +596,7 @@ void KPartition(Thread tID,
 
         auto flip = !(k == ES || k == VC || k == IF || k == LD);
        
-        if (__o__.prod == Product::RNA || d->__o__.prod == Product::Meta)
+        if (__o__.prod == Product::RNA || __o__.prod == Product::Meta)
         {
            flip = false;
         }


### PR DESCRIPTION
The latest commit broke the make build.

`src/kallisto/Kallisto.cpp: In lambda function:
src/kallisto/Kallisto.cpp:599:43: error: ‘d’ was not declared in this scope
if (o.prod == Product::RNA || d->o.prod == Product::Meta)
^
make: *** [src/kallisto/Kallisto.o] Error 1`

The change in this update makes it so the application builds.  I believe the logic is correct, but I honestly haven't given a thorough review of all the code.

P.S. Thank you for your work on sequins!  We're all super fans :)